### PR TITLE
Add support for non-JSON API responses + update embed code example to use Embed tokens & latest Web component

### DIFF
--- a/Luzmo.php
+++ b/Luzmo.php
@@ -94,7 +94,18 @@ class Luzmo {
       CURLOPT_POSTFIELDS     => $payload
     );
     curl_setopt_array($curl, $curl_options);
-    return json_decode(curl_exec($curl), $this->format === 'array' ? true : false);
+    $response = curl_exec($curl);
+    $content_type = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
+    
+    // Check content type and handle accordingly
+    if (strpos($content_type, 'application/json') !== false) {
+      // JSON response from Luzmo API -> decode
+      return json_decode($response, $this->format === 'array');
+    }
+    else {
+      // Non-JSON response (e.g. image or PDF export) -> return as such
+      return $response;
+    }
   }
 
 }

--- a/Luzmo.php
+++ b/Luzmo.php
@@ -98,13 +98,13 @@ class Luzmo {
     $content_type = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
     
     // Check content type and handle accordingly
-    if (strpos($content_type, 'application/json') !== false) {
-      // JSON response from Luzmo API -> decode
-      return json_decode($response, $this->format === 'array');
-    }
-    else {
+    if (strpos($content_type, 'application/json') === false) {
       // Non-JSON response (e.g. image or PDF export) -> return as such
       return $response;
+    }
+    else {
+      // JSON response from Luzmo API -> decode
+      return json_decode($response, $this->format === 'array');
     }
   }
 

--- a/example-embedding.php
+++ b/example-embedding.php
@@ -7,22 +7,27 @@ use Luzmo\Luzmo;
 $client = Luzmo::initialize('< Your API key >', '< Your API token >'); // Fill in your API key & token
 // Set third, optional property to https://api.luzmo.com/ (default, EU multitenant env), https://api.us.luzmo.com (US multitenant env) or your specific VPC address
 
-// On page requests of pages containing embedded dashboards, request an "authorization"
-$integrationId = 'b9a0c66e-2986-4b0f-913f-af54d9132453'; // Fill in your integration ID
+// On page requests of pages containing embedded dashboards, request an "Authorization"
 $authorization = $client->create('authorization', array(
-  'type' => 'sso',
-  'integration_id' => $integrationId,
-  'expiry' => '24 hours',
-  'inactivity_interval' => '10 minutes',
-  // user information
-  'username' => '12345678', // unique, immutable username
-  'name' => 'John Doe',
-  'email' => 'johndoe@burritosnyc.com',
-  'suborganization' => 'Burritos NYC',
-  'role' => 'viewer',
-  // data restrictions 
-  'metadata' => array(
-    'client_id' => 1234 // specify your parameter names and values
+  'type' => 'embed',
+  // End-user information
+  'username' => '12345678',             // unique, immutable username for your end-user
+  'name' => 'John Doe',                 // Name of your enduser
+  'email' => 'johndoe@burritosnyc.com', // Email address of your enduser
+  'suborganization' => 'Burritos NYC',  // Suborganization/tenancy of your end-user
+  'role' => 'viewer',                   // role of your end-user
+  // Data restrictions 
+  'parameter_overrides' => array(
+    'client_id' => 1234                 // Specify your parameter names and values
+  ),
+  // End-user dashboards & datasets access
+  'access' => array(
+    'collections' => array(
+      array(
+        'id' => '<a collection id>',    // Fill in a collection ID
+        'inheritRights' => 'use'
+      )
+    )
   )
 ));
 ?>

--- a/example-embedding.php
+++ b/example-embedding.php
@@ -46,11 +46,13 @@ $authorization = $client->create('authorization', array(
       <p>Try to resize your page to see the dashboard adapting to different screen modes.</p>
     </div>
     <luzmo-dashboard
-        appServer="https://app.luzmo.com/"> 
+        appServer="https://app.luzmo.com/"
+        apiHost="https://api.luzmo.com">
         <!-- Set appServer to https://app.luzmo.com/ (default, EU multitenant env), https://app.us.luzmo.com (US multitenant env) or your specific VPC address -->
+        <!-- Set apiHost to https://api.luzmo.com/ (default, EU multitenant env), https://api.us.luzmo.com (US multitenant env) or your specific VPC API address -->
     </luzmo-dashboard>
     <!-- Check out the latest version on our npm page, as well as our components for frameworks such as react, vue and angular -->
-    <script src="https://cdn.luzmo.com/js/luzmo-embed/5.0.0/luzmo-embed.min.js" charset="utf-8"></script>
+    <script src="https://cdn.luzmo.com/js/luzmo-embed/5.0.7/luzmo-embed.min.js" charset="utf-8"></script>
     <script type="text/javascript">
       const dashboardElement = document.querySelector('luzmo-dashboard');
       // We can now set the key and token to the dashboard component.
@@ -60,7 +62,7 @@ $authorization = $client->create('authorization', array(
       dashboardElement.getAccessibleDashboards()
         .then(dashboards => {
           if (dashboards.length > 0) {
-          dashboardElement.dashboardId = dashboards[0].id;
+            dashboardElement.dashboardId = dashboards[0].id;
           };
         });
     </script>


### PR DESCRIPTION
1. Add support for non-JSON API responses (e.g. the Export API service might return a PNG/PDF file instead of a JSON response).
2. Update embed code example to use Embed tokens & latest Web component